### PR TITLE
Update Cilium upgradeCompatibility to 1.18

### DIFF
--- a/system/cilium/values.yaml
+++ b/system/cilium/values.yaml
@@ -64,4 +64,4 @@ serviceAccounts:
   operator:
     name: cilium-operator
 tunnelProtocol: vxlan
-upgradeCompatibility: "1.17"
+upgradeCompatibility: "1.18"


### PR DESCRIPTION
## Summary

- `upgradeCompatibility` を `"1.17"` → `"1.18"` に更新

Cilium v1.19 へのアップグレード（#607）に合わせて設定を更新する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)