### PR TITLE
chore(renovate): add minimumReleaseAge of 1 day

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":dependencyDashboard"],
+  "minimumReleaseAge": "1 day",
   "kubernetes": {
     "managerFilePatterns": [
       "/applications/.+\\.yaml$/",


### PR DESCRIPTION
## Summary

- `minimumReleaseAge: "1 day"` をトップレベルに追加

## Why

Renovate がタグ検知直後に PR を作成するため、リリースノートがまだ空だったりコンテナイメージがレジストリに届いていないタイミングで PR が来る問題があった。1 日待つことで、リリースが安定した後に PR が作成されるようになる。

## Reviewer notes

すべての datasource (docker, github-releases, github-tags) に一律適用される。特定パッケージを即時更新したい場合は `packageRules` 内で `minimumReleaseAge: "0 days"` を上書きすれば除外できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)